### PR TITLE
Sync mediaplayer across monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Open `"$HOME/.config/waybar/waybar-mediaplayer/src/config.json` and change `play
 Put the following in `$HOME/.config/waybar/config`:
 
 ```
-"modules-left": ["image", "custom/mediaplayer"],
+"modules-left": ["image", "custom/mediaplayer", "custom/mediaplayer/start"],
 ```
 
 ```
@@ -80,7 +80,8 @@ Put the following in `$HOME/.config/waybar/config`:
 },
 
 "custom/mediaplayer": {
-    "exec": "$HOME/.config/waybar/waybar-mediaplayer/src/mediaplayer monitor",
+    "exec": "cat /tmp/waybar-mediaplayer.json",
+    "interval": 1,
     "return-type": "json",
     "format": "{}",
     "on-click": "$HOME/.config/waybar/waybar-mediaplayer/src/mediaplayer play-pause",
@@ -88,6 +89,13 @@ Put the following in `$HOME/.config/waybar/config`:
     "on-scroll-down": "$HOME/.config/waybar/waybar-mediaplayer/src/mediaplayer previous",
     "min-length": 20,
     "max-length": 20
+},
+
+"custom/mediaplayer/start": {
+    "exec": "$HOME/.config/waybar/waybar-mediaplayer/src/mediaplayer monitor",
+    "interval": "once",
+    "format": "",
+    "hide_on_empty": true
 },
 ```
 

--- a/src/config.json
+++ b/src/config.json
@@ -1,5 +1,5 @@
 {
-  "refresh_interval": 500,
+  "refresh_interval": 1000,
   "is_notification": false,
   "notification_min_interval": 2,
   "widget_length": 20,

--- a/src/mediaplayer
+++ b/src/mediaplayer
@@ -18,6 +18,9 @@ from collections import namedtuple
 from functools import partial
 from pathlib import Path
 
+import os
+import fcntl
+
 import gi
 import requests
 import syncedlyrics
@@ -25,6 +28,10 @@ from PIL import Image
 
 gi.require_version("Playerctl", "2.0")
 from gi.repository import GLib, Playerctl  # noqa: E402
+
+LOCK_FILE = "/tmp/waybar-mediaplayer.lock"
+ALBUM_ART_FILE = "/tmp/waybar-mediaplayer-art"
+OUTPUT_FILE = "/tmp/waybar-mediaplayer.json"
 
 # Internal global variables
 config = None
@@ -41,6 +48,22 @@ format_class = None
 icons = {"play": " ", "stop": " "}
 is_text_rotating = None
 lyrics = dict()
+
+
+def acquire_lock():
+    try:
+        lock = open(LOCK_FILE, 'w')
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return lock
+    except IOError:
+        print("Another instance of waybar-mediaplayer is already running", file=sys.stderr)
+        sys.exit(1)
+
+
+def release_lock(lock):
+    fcntl.flock(lock, fcntl.LOCK_UN)
+    lock.close()
+    os.remove(LOCK_FILE)
 
 
 def on_player_appeared(manager, player, requested_player):
@@ -143,8 +166,8 @@ def write_output(text=None, class_=None, tooltip=""):
         "class": class_,
         "tooltip": "<span>" + tooltip + "</span>",
     }
-    sys.stdout.write(json.dumps(output) + "\n")
-    sys.stdout.flush()
+    with open(OUTPUT_FILE, 'w') as f:
+        f.write(json.dumps(output))
 
 
 def register_refresh_interval_callback(player, manager):
@@ -660,4 +683,8 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    lock = acquire_lock()
+    try:
+        main()
+    finally:
+        release_lock(lock)


### PR DESCRIPTION
I was facing an issue where the mediaplayer was displaying differently on each of my monitors. This PR outputs to a single file that each waybar instance reads from.