### PR TITLE
use absolute path to style.css in mkstyle

### DIFF
--- a/src/mkstyle
+++ b/src/mkstyle
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import argparse
 import json
 import math
@@ -45,9 +46,13 @@ def parse_arguments():
 
 args = parse_arguments()
 outfp = args.output_file
-print(f"Writing output to {outfp}")
 
-outfh = open(outfp, "w", encoding="utf8")
+script_dir = os.path.dirname(os.path.abspath(__file__))
+abs_outfp = os.path.join(script_dir, outfp)
+
+print(f"Writing output to {abs_outfp}")
+
+outfh = open(abs_outfp, "w", encoding="utf8")
 
 for i in np.arange(0, 100 + interval, interval):
     i = float(i)
@@ -62,5 +67,4 @@ for i in np.arange(0, 100 + interval, interval):
     );
 }}\n"""
     )
-
 outfh.close()


### PR DESCRIPTION
So the issue was:
`mkstyle` would just create `style.css` file in whatever directory I ran the script from. It even overwrote my waybar's `style.css` at some point, sadly. 
All of this while I was trying to figure out why it didn't do what it had to - change the stylesheet in src/ folder.

So in this PR it constructs absolute path to `style.css`, based on the directory that `mkstyle` is in.

Tested on my arch install, works as expected. 

(Aso full disclosure, I had trouble creating virtual environment, so I just installed necessary dependencies through pacman and it all worked. I think what I described would reproduce regardless.)